### PR TITLE
Added contract verification in the chain extension

### DIFF
--- a/runtime/integration-tests/contracts-data/ink/native_fungible_token/Cargo.toml
+++ b/runtime/integration-tests/contracts-data/ink/native_fungible_token/Cargo.toml
@@ -3,6 +3,7 @@ edition = "2021"
 name = "native_fungible_token"
 version = "3.0.1"
 authors = ["Nimish Agrawal nimish@lagu.na"]
+description = "A system-contract used to expose native token as multilayer assets in ERC-20 standard"
 
 [dependencies]
 ink_primitives = { version = "~3.0", default-features = false }

--- a/runtime/integration-tests/contracts-data/ink/native_fungible_token/lib.rs
+++ b/runtime/integration-tests/contracts-data/ink/native_fungible_token/lib.rs
@@ -10,7 +10,7 @@ use scale::{Decode, Encode};
 pub enum ExtensionError {
 	InvalidTokenId,
 	InsufficientBalance,
-	InsufficientAllowance,
+	AccessDenied,
 	UnknownStatusCode,
 	InvalidScaleEncoding,
 }
@@ -27,6 +27,7 @@ impl ink_env::chain_extension::FromStatusCode for ExtensionError {
 			0 => Ok(()),
 			1 => Err(Self::InvalidTokenId),
 			2 => Err(Self::InsufficientBalance),
+			403 => Err(Self::AccessDenied),
 			_ => Err(Self::UnknownStatusCode),
 		}
 	}
@@ -132,7 +133,7 @@ mod native_fungible_token {
 				panic!("Invalid tokenId")
 			}
 
-			// Allows instantaition from priviledged account only (ROOT for now)
+			// Allows instantaition from privileged account only (ROOT for now)
 			if Self::env().extension().whitelist_contract().is_err() {
 				panic!("Failed to whitelist the contract")
 			}

--- a/runtime/src/impl_pallet_contracts/chain_extensions.rs
+++ b/runtime/src/impl_pallet_contracts/chain_extensions.rs
@@ -24,7 +24,8 @@ impl ChainExtension<Runtime> for DemoExtension {
 		let mut env = env.buf_in_buf_out();
 		match func_id {
 			0010 => {
-				// @todo: Whitelist contract after verification
+				// Whitelist contract after verification
+				// @dev: Currently only system-contracts are whitelisted
 				Ok(RetVal::Converging(0))
 			},
 			1000 => {
@@ -110,7 +111,11 @@ impl ChainExtension<Runtime> for DemoExtension {
 						// @dev: This is an UNSAFE method. Only whitelisted contracts can access it!
 
 						let contract: AccountId = env.ext().address().clone();
-						//@todo: Verify that the contract is authorised to do this operation
+
+						// Verify that the contract is authorised to do this operation
+						if !crate::SudoContracts::is_system_contract(contract) {
+							return Ok(RetVal::Converging(403))
+						}
 
 						let (_, from, to, value): (u32, AccountId, AccountId, Balance) =
 							env.read_as()?;


### PR DESCRIPTION
For now, Only contracts deployed by the `pallet-system-contract-deployer` are allowed to use restricted chain extension features. Later, We can extend this functionality to general contracts depending upon the use case by implementing an Access-Control-Pallet