### PR TITLE
Implemented whitelist contract chain-ext method

### DIFF
--- a/runtime/integration-tests/src/contracts/consume_native_token.rs
+++ b/runtime/integration-tests/src/contracts/consume_native_token.rs
@@ -100,6 +100,20 @@ mod tests {
 
                 sel_constructor.append(&mut 0_u32.encode());
 
+				// Verify that non-root accounts cannot deploy an instance of native_fungible_token
+				frame_support::assert_err_ignore_postinfo!(
+					Contracts::instantiate_with_code(
+						Origin::signed(ALICE),
+						0,
+						MAX_GAS,
+						None,
+						blob.clone(),
+						sel_constructor.clone(),
+						vec![]
+					),
+					pallet_contracts::Error::<Runtime>::ContractTrapped
+				);
+
                 let erc20_contract_addr = deploy_system_contract(blob, sel_constructor);
 
 				// 2. Test name()

--- a/runtime/src/impl_pallet_contracts/chain_extensions.rs
+++ b/runtime/src/impl_pallet_contracts/chain_extensions.rs
@@ -8,7 +8,7 @@ use pallet_contracts::chain_extension::{
 	ChainExtension, Environment, Ext, InitState, RetVal, SysConfig, UncheckedFrom,
 };
 use primitives::{AccountId, Balance, CurrencyId, TokenId, TokenMetadata};
-use sp_runtime::DispatchError;
+use sp_runtime::{traits::AccountIdConversion, DispatchError};
 
 #[derive(Default)]
 pub struct DemoExtension;
@@ -29,7 +29,14 @@ impl ChainExtension<Runtime> for DemoExtension {
 			10 => {
 				// Whitelist contract after verification
 				// @dev: Currently only system-contracts are whitelisted
-				Ok(RetVal::Converging(0))
+				let caller: AccountId = env.ext().caller().clone();
+				let approved_deployer =
+					<Runtime as pallet_system_contract_deployer::Config>::PalletId::get()
+						.try_into_account()
+						.expect("Invalid PalletId");
+
+				let res = (caller == approved_deployer);
+				Ok(RetVal::Converging((!res).into()))
 			},
 			100 => {
 				let arg: [u8; 32] = env.read_as()?;


### PR DESCRIPTION
This ensures system-contract (with restricted deployment filter) can only be deployed by ROOT